### PR TITLE
Another attempt to work on the website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,12 +6,12 @@
 # 'jekyll serve'. If you change this file, please restart the server process.
 
 # Site settings
-title: Octave
+title: GNU Octave
 email: maintainers@octave.org
 description: > # this means to ignore newlines until "baseurl:"
-  Octave is a programming language for scientific computing.
+  GNU Octave is a programming language for scientific computing.
 baseurl: "/octave-web" # the subpath of your site, e.g. /blog
-url: "//www.octave.org" # the base hostname & protocol for your site
+url: "//www.gnu.org" # the base hostname & protocol for your site
 wiki_url: "//wiki.octave.org"
 faq_url: "//wiki.octave.org/faq"
 docs_url: "//www.gnu.org/software/octave/doc/interpreter/"

--- a/_config.yml
+++ b/_config.yml
@@ -6,15 +6,15 @@
 # 'jekyll serve'. If you change this file, please restart the server process.
 
 # Site settings
-title: Octave
+title: GNU Octave
 email: maintainers@octave.org
 description: > # this means to ignore newlines until "baseurl:"
-  Octave is a programming language for scientific computing.
-baseurl: "/octave-web" # the subpath of your site, e.g. /blog
-url: "//www.octave.org" # the base hostname & protocol for your site
-wiki_url: "//wiki.octave.org"
-faq_url: "//wiki.octave.org/faq"
-docs_url: "//www.gnu.org/software/octave/doc/interpreter/"
+  GNU Octave is a programming language for scientific computing.
+baseurl: "/software/octave/new" # the subpath of your site, e.g. /blog
+url: "https://www.gnu.org" # the base hostname & protocol for your site
+wiki_url: "http://wiki.octave.org"
+faq_url: "http://wiki.octave.org/faq"
+docs_url: "https://www.gnu.org/software/octave/doc/interpreter/"
 maintainers_email: "maintainers@octave.org"
 help_email: "help@octave.org"
 irc_channel: "#octave"

--- a/_config_octave.yml
+++ b/_config_octave.yml
@@ -1,0 +1,6 @@
+# Site settings for deployment under https://www.gnu.org/software/octave
+# build with
+#
+# > jekyll build --config _config.yml,_config_octave.yml
+#
+baseurl: "/software/octave/new" # the subpath of your site, e.g. /blog

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,10 +20,10 @@
 				<dd><a href="http://webchat.freenode.net/?channels=octave&uio=MT1mYWxzZSYyPXRydWUmMTI9dHJ1ZQda">{{site.irc_channel}}</a></dd>
 			</div>
 			<div class="columns medium-3">
-				<dt><a href="{{ "/bugs/" | prepend: site.baseurl }}">Reporting Bugs</a></dt>        
-				<dt><a href="{{ "/support-expectations/" | prepend: site.baseurl }}">Support Expectations</a></dt> 
-				<dt><a href="{{ "/commercial-support/" | prepend: site.baseurl }}">Commercial Support</a></dt>  
-				<dt><a href="{{ "/donate/" | prepend: site.baseurl }}">Donate</a></dt>      
+				<dt><a href="{{ "/bugs/" | prepend: site.baseurl }}">Reporting Bugs</a></dt>
+				<dt><a href="{{ "/support-expectations/" | prepend: site.baseurl }}">Support Expectations</a></dt>
+				<dt><a href="{{ "/commercial-support/" | prepend: site.baseurl }}">Commercial Support</a></dt>
+				<dt><a href="{{ "/donate/" | prepend: site.baseurl }}">Donate</a></dt>
 			</div>
 			</div>
 		</dl>
@@ -47,7 +47,7 @@
 			<div class="text-center">
 				<p>Octave is free software under the <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public License.</a></p>
 				<small>
-					Copyright © 1998-2015 John W. Eaton. Verbatim copying and distribution is permitted in any medium, provided this notice is preserved. 
+					Copyright © 1998-2016 John W. Eaton. Verbatim copying and distribution is permitted in any medium, provided this notice is preserved. 
 				</small>
 			</div>
 		</div>

--- a/_includes/install.html
+++ b/_includes/install.html
@@ -8,7 +8,7 @@
 <div class="tabs-content">
   <div class="content active" id="linux">
     <p>
-      Executable versions of Octave for GNU/Linux systems are provided by the individual distributions. Distributions known to package Octave include <a href="//debian.org">Debian</a>, <a href="//ubuntu.org">Ubuntu</a>, <a href="//fedoraproject.org">Fedora</a>, <a href="//gentoo.org">Gentoo</a>, and <a href="//opensuse.org">SuSE</a>. These packages are created by volunteers. The delay between an Octave source release and the availability of a package for a particular GNU/Linux distribution varies.
+      Executable versions of GNU Octave for GNU/Linux systems are provided by the individual distributions. Distributions known to package Octave include <a href="//debian.org">Debian</a>, <a href="//ubuntu.org">Ubuntu</a>, <a href="//fedoraproject.org">Fedora</a>, <a href="//gentoo.org">Gentoo</a>, and <a href="//opensuse.org">SuSE</a>. These packages are created by volunteers. The delay between an Octave source release and the availability of a package for a particular GNU/Linux distribution varies.
     </p>
   </div>
   <div class="content" id="mac">
@@ -28,7 +28,7 @@
   </div>
   <div class="content" id="source">
     <p>
-      The latest released version of Octave is always available from <a href="ftp://ftp.gnu.org/gnu/octave">ftp://ftp.gnu.org/gnu/octave</a>. 
+      The latest released version of Octave is always available from <a href="ftp://ftp.gnu.org/gnu/octave">ftp://ftp.gnu.org/gnu/octave</a>.
     </p>
   </div>
 </div>

--- a/_posts/2015-05-29-octave-4.0.0-released.markdown
+++ b/_posts/2015-05-29-octave-4.0.0-released.markdown
@@ -1,17 +1,25 @@
 ---
 layout: post
-title:  "Octave 4.0.0 Released"
+title:  "GNU Octave 4.0.0 Released"
 date:   2015-05-29
 categories: releases
 ---
 
-Version 4.0.0 has been released and is now available for download. Octave 4.0 is a major new release with many new features, including a graphical user interface, support for classdef object-oriented programming, better compatibility with Matlab, and many new and improved functions.
+Version 4.0.0 has been released and is now available for download.
+Octave 4.0 is a major new release with many new features:
 
-An official Windows binary installer is also available from [ftp://ftp.gnu.org/gnu/octave/windows/octave-4.0.0_0-installer.exe][installer]
+- including a graphical user interface,
+- support for classdef object-oriented programming,
+- better compatibility with Matlab, and
+- many new and improved functions.
 
-A list of important user-visible changes is available [here][news], by selecting the Release Notes item in the News menu of the GUI, or by typing news at the Octave command prompt.
+An official [Windows binary installer][] is available.
 
-Thanks to the many people who contributed to this release! 
+A list of important user-visible changes is available [here][news],
+by selecting the Release Notes item in the News menu of the GUI,
+or by typing `news` at the Octave command prompt.
+
+Thanks to the many people who contributed to this release!
 
 [news]: http://octave.org/NEWS-4.0.html
-[installer]: ftp://ftp.gnu.org/gnu/octave/windows/octave-4.0.0_0-installer.exe
+[Windows binary installer]: ftp://ftp.gnu.org/gnu/octave/windows/octave-4.0.0_0-installer.exe

--- a/_posts/2016-03-23-octave-4.0.1-released.markdown
+++ b/_posts/2016-03-23-octave-4.0.1-released.markdown
@@ -1,0 +1,19 @@
+---
+layout: post
+title:  "GNU Octave 4.0.1 Released"
+date:   2016-03-23
+categories: releases
+---
+
+Version 4.0.1 has been released and is now available for [download][].
+Octave 4.0.1 is a [bug fixing release][].
+
+Octave 4.0, released in May 2015,
+was a major new version with many new features,
+including a graphical user interface,
+support for classdef object-oriented programming,
+better compatibility with Matlab,
+and many new and improved functions.
+
+[download]: http://www.octave.org/download.html
+[bug fixing release]: http://www.octave.org/fixes-4-0-1.html

--- a/_posts/2016-07-02-octave-4.0.3-released.markdown
+++ b/_posts/2016-07-02-octave-4.0.3-released.markdown
@@ -1,0 +1,15 @@
+---
+layout: post
+title:  "GNU Octave 4.0.3 Released"
+date:   2016-07-02
+categories: releases
+---
+
+Octave Version 4.0.3 has been released and is now available for [download][].
+This version is another [bug fixing release][].
+
+An official [Windows binary installer][] is also available.
+
+[download]: http://www.octave.org/download.html
+[bug fixing release]: http://www.octave.org/fixes-4-0-3.html
+[Windows binary installer]: ftp://ftp.gnu.org/gnu/octave/windows/octave-4.0.3-installer.exe

--- a/humans.txt
+++ b/humans.txt
@@ -1,13 +1,13 @@
 About GNU Octave
 ----------------
-Octave is a free programming language for scientific computation.
+GNU Octave is a free programming language for scientific computation.
 
 
 Documentation
 -------------
-Copyright (c) 1998-2015 John W. Eaton. Verbatim copying and distribution is permitted in any medium, provided this notice is preserved. 
+Copyright (c) 1998-2016 John W. Eaton. Verbatim copying and distribution is permitted in any medium, provided this notice is preserved.
 
 
 Website Design
 --------------
-Copyright (c) 2015 Alex Krolick. Verbatim copying and distribution is permitted in any medium.
+Copyright (c) 2015-2016 Alex Krolick. Verbatim copying and distribution is permitted in any medium.

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ layout: default
 
 <section id="syntax">
   <h3>Syntax Examples</h3>
-  
+
   <div class="row">
     <div class="columns medium-12">
       <p>
@@ -40,7 +40,7 @@ layout: default
       </p>
     </div>
   </div>
-  
+
   <div class="row">
     <div class="columns medium-4" >
       <p>Solve systems of equations with linear algebra operations on <strong>vectors</strong> and <strong>matrices</strong></p>
@@ -51,16 +51,16 @@ b = [4; 9; 2] % Column vector
 A = [ 3 4 5;
       1 3 1;
       3 5 9 ]
-x = A \ b    % Solve the system by inverting A
+x = A \ b     % Solve the system by inverting A
 {% endhighlight %}
      </div>
   </div>
-  
+
   <div class="row">
      <div class="columns medium-4">
         <p>Visualize data with <strong>high-level plot commands</strong> in 2D and 3D</p>
      </div>
-     <div class="columns medium-8">     
+     <div class="columns medium-8">
 {% highlight matlab %}
 x = -10:0.1:10 % Create an evenly-spaced vector from -10..10
 y = sin(x)     % y is also a vector
@@ -85,7 +85,7 @@ plot(x,y)
     </div>
     <div class="columns medium-4">
       <a href="#" data-reveal-id="guiModal">
-        <img src="https://upload.wikimedia.org/wikipedia/en/4/48/Octave-4.0.0-rc1-Qt5.4-Linux.png" title="Octave-4.0.0-rc1-Qt5.4-Linux by Qtguy00 - Own work. Licensed under CC BY-SA 3.0 via Wikipedia"/>
+        <img src="https://www.gnu.org/software/octave/images/screenshot-2016-small.png" title="GNU Octave 4.0.3 - Licensed under CC BY-SA 3.0"/>
       </a>
     </div>
   </div>


### PR DESCRIPTION
Finally, I think to have found a nice solution to stay compatible to the gh pages and to easily deploy the homepage at gnu.org. The "trick" I found at https://stackoverflow.com/questions/27386169/change-site-url-to-localhost-during-jekyll-local-development/

Now I simply provide a seperate config file, only with the important different baseurl `_config_octave.yml` which can be compiled with

```
jekyll build --config _config.yml,_config_octave.yml
```

And I did some updates regarding dates, feeds, and so on. Are you okay with it?
